### PR TITLE
contents: remove DOH_CONTENT_TYPE_PARAM, it's not used in draft-13

### DIFF
--- a/dohproxy/constants.py
+++ b/dohproxy/constants.py
@@ -9,7 +9,6 @@
 
 DOH_URI = '/dns-query'
 DOH_MEDIA_TYPE = 'application/dns-message'
-DOH_CONTENT_TYPE_PARAM = 'ct'
 DOH_DNS_PARAM = 'dns'
 DOH_H2_NPN_PROTOCOLS = ['h2']
 DOH_CIPHERS = 'ECDHE+AESGCM'

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -141,17 +141,7 @@ def extract_ct_body(params: Dict[str, List[str]]) -> Tuple[str, bytes]:
         body.
     :raises: a DOHParamsException with an explanatory message.
     """
-    if constants.DOH_CONTENT_TYPE_PARAM in params and \
-            len(params[constants.DOH_CONTENT_TYPE_PARAM]):
-        ct = params[constants.DOH_CONTENT_TYPE_PARAM][0]
-        if not ct:
-            # An empty value indicates the default
-            # application/dns-udpwireformat type
-            ct = constants.DOH_MEDIA_TYPE
-    else:
-        raise server_protocol.DOHParamsException(
-            b'Missing Content Type Parameter')
-
+    ct = constants.DOH_MEDIA_TYPE
     if constants.DOH_DNS_PARAM in params and \
             len(params[constants.DOH_DNS_PARAM]):
         try:
@@ -208,7 +198,6 @@ def build_query_params(dns_query):
     """
     return {
         constants.DOH_DNS_PARAM: doh_b64_encode(dns_query),
-        constants.DOH_CONTENT_TYPE_PARAM: constants.DOH_MEDIA_TYPE,
     }
 
 


### PR DESCRIPTION
The 'ct' thing is no longer used in current (draft-13) DoH URLs

This is a follow-up to #42 to make the support properly draft-13 complient